### PR TITLE
make bpfink more fail-tolerant during startup & runtime (#46)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -327,6 +327,10 @@ func (c Configuration) resolvePath(pathFull string) (string, os.FileInfo) {
 			}
 			return "", nil
 		}
+		if fileInfo.Mode()&os.ModeSocket != 0 {
+			return "", nil
+		}
+
 		fi = fileInfo
 		pathFull = linkPath
 	}
@@ -409,7 +413,7 @@ func (c Configuration) watcher() (*pkg.Watcher, error) {
 
 	for _, consumer := range consumers {
 		if err := consumer.Init(); err != nil {
-			logger.Fatal().Err(err).Msg("failed to init consumer")
+			logger.Error().Err(err).Msg("failed to init consumer")
 		}
 	}
 	return pkg.NewWatcher(func(w *pkg.Watcher) {
@@ -472,10 +476,7 @@ func run() error {
 	metrics.RecordByInstalledHost()
 	// send version metric
 	metrics.RecordVersion(Version)
-	err = metrics.RecordBPFMetrics()
-	if err != nil {
-		logger.Fatal().Err(err).Msg("error starting bpf metrics")
-	}
+	metrics.RecordBPFMetrics()
 	key := make([]byte, keySize)
 	if config.Keyfile == "" {
 		if _, err := io.ReadFull(rand.Reader, key); err != nil {

--- a/pkg/graphite.go
+++ b/pkg/graphite.go
@@ -119,7 +119,7 @@ func (m *Metrics) RecordByInstalledHost() {
 }
 
 // RecordBPFMetrics send metrics for BPF hits and misses per probe
-func (m *Metrics) RecordBPFMetrics() error {
+func (m *Metrics) RecordBPFMetrics() {
 	go func() {
 		for range time.Tick(m.MetricsInterval) {
 			BPFMetrics, err := m.fetchBPFMetrics()
@@ -138,7 +138,6 @@ func (m *Metrics) RecordBPFMetrics() error {
 			}
 		}
 	}()
-	return nil
 }
 
 func (m *Metrics) fetchBPFMetrics() (map[string]bpfMetrics, error) {
@@ -150,7 +149,7 @@ func (m *Metrics) fetchBPFMetrics() (map[string]bpfMetrics, error) {
 	}
 	defer func() {
 		if err := file.Close(); err != nil {
-			log.Fatal(err)
+			log.Print(err)
 		}
 	}()
 
@@ -209,7 +208,7 @@ func (m *Metrics) fetchBPFMetrics() (map[string]bpfMetrics, error) {
 	}
 
 	if err := scanner.Err(); err != nil {
-		log.Fatal(err)
+		log.Print(err)
 	}
 	return BPFMetrics, nil
 }

--- a/pkg/watcher.go
+++ b/pkg/watcher.go
@@ -209,11 +209,7 @@ func (w *Watcher) removeInode(key uint64) {
 func (w *Watcher) Start() error {
 	defer func() {
 		if i := recover(); i != nil {
-			w.Fatal().Msgf("Panic Caught")
 			w.Fatal().Msgf("Caught panic: %v", i)
-			if err := w.Start(); err != nil {
-				w.Error().Err(err)
-			}
 		}
 	}()
 	w.Debug().Msgf("consumer Count: %v", len(w.Consumers))


### PR DESCRIPTION
1. Bad consumer initialization during startup does not lead to crash anymore
2. BPF kernel metrics file bad closing doesn't lead to crash anymore
3. Links to socket files are not monitored anymore
4. Removed some unreachable/redundant code

Co-authored-by: Nick Loginov <>